### PR TITLE
Add another notation to libNames for OS X.

### DIFF
--- a/source/derelict/glfw3/glfw3.d
+++ b/source/derelict/glfw3/glfw3.d
@@ -39,7 +39,7 @@ private {
     static if( Derelict_OS_Windows )
         enum libNames = "glfw3.dll";
     else static if( Derelict_OS_Mac )
-        enum libNames = "libglfw.3.dylib";
+        enum libNames = "libglfw.3.dylib,libglfw3.dylib";
     else static if( Derelict_OS_Posix )
         enum libNames = "libglfw3.so,libglfw.so.3,/usr/local/lib/libglfw3.so,/usr/local/lib/libglfw.so.3";
     else


### PR DESCRIPTION
I just installed glfw3 on OS X using homebrew and noticed that the shared library file was named libglfw3.dylib (without the additional dot).

Now DerelictGLFW3 seems to be able to load the library.
